### PR TITLE
[FND-2658] Add ship job

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -29,3 +29,10 @@ jobs:
         with:
           push: true
           tags: ghcr.io/trusted/url-to-pdf-api:c-${{ github.sha }}
+
+  ship:
+    needs: build-and-publish
+    uses: trusted/shared-workflows/.github/workflows/update_kube_state.yml@main
+    with:
+      repo_name: url-to-pdf-api
+      commit_sha: ${{ github.sha }}


### PR DESCRIPTION
This calls the workflow created in [this PR](https://github.com/trusted/shared-workflows/pull/14), which will updates the `kube-state` repository with the recently built docker image. 